### PR TITLE
Fix #121: index.jsp missing 404

### DIFF
--- a/gradle/i2p-make-plugin.gradle
+++ b/gradle/i2p-make-plugin.gradle
@@ -187,7 +187,9 @@ class I2PPlugin implements Plugin<Project> {
 
         project.task('thinWar', type: War, dependsOn: project.classes) {
             destinationDir = project.file("$project.buildDir/thinWar")
-            classpath = project.war.classpath.minus(project.configurations.runtime)
+            classpath = project.thinWar.classpath.filter { lib -> !(
+                lib.name.endsWith('.jar')
+            )}
         }
 
         project.task('packWebapp', type: Pack200Task) {


### PR DESCRIPTION
Fixed #121 index.jsp missing 404 error.

The problem is that Jetty tries to load .jar files inside the .war file. But it won't work. 

The solution is to remove all jar files inside the war file for the plugin.

See also: https://stackoverflow.com/questions/55733666/cannot-deploy-war-in-jetty-9-4-16-v20190411-receiving-filenotfoundexception-for